### PR TITLE
feat(query-tests): set up query tests with sparql files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,8 @@
         "es2021": true
     },
     "ignorePatterns": [
-        "out"
+        "out",
+        "*.sparql"
     ],
     "extends": [
         "google",

--- a/jest_setup.js
+++ b/jest_setup.js
@@ -1,1 +1,2 @@
 global.performance = require('perf_hooks').performance;
+jest.setTimeout(30 * 1000);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "@types/sparql-http-client": "^2.2.7",
+        "glob": "^7.2.0",
         "sparql-http-client": "^2.4.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.0",
         "@babel/preset-typescript": "^7.16.0",
+        "@types/glob": "^7.2.0",
         "@types/jest": "^27.0.2",
         "@typescript-eslint/eslint-plugin": "^5.3.0",
         "@typescript-eslint/parser": "^5.3.0",
@@ -2321,6 +2323,16 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -2368,6 +2380,12 @@
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+      "dev": true
+    },
+    "node_modules/@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -2972,14 +2990,12 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3178,8 +3194,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -4075,8 +4090,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -4163,7 +4177,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4394,7 +4407,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -5527,7 +5539,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5767,7 +5778,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8733,6 +8743,16 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -8780,6 +8800,12 @@
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+      "dev": true
+    },
+    "@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
       "dev": true
     },
     "@types/node": {
@@ -9217,14 +9243,12 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -9378,8 +9402,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -10076,8 +10099,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -10139,7 +10161,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -10303,7 +10324,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -11183,7 +11203,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -11368,8 +11387,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.16.0",
     "@babel/preset-typescript": "^7.16.0",
+    "@types/glob": "^7.2.0",
     "@types/jest": "^27.0.2",
     "@typescript-eslint/eslint-plugin": "^5.3.0",
     "@typescript-eslint/parser": "^5.3.0",
@@ -43,6 +44,7 @@
   },
   "dependencies": {
     "@types/sparql-http-client": "^2.2.7",
+    "glob": "^7.2.0",
     "sparql-http-client": "^2.4.0"
   }
 }

--- a/src/queries/query_runner.test.ts
+++ b/src/queries/query_runner.test.ts
@@ -1,0 +1,32 @@
+import { QueryRunner } from './query_runner';
+import { QueryCollection } from './sparql/query_collection';
+
+const collection = new QueryCollection();
+const queries = collection.getQueries();
+
+// TODO: consider making a way to run queries against multiple endpoints
+const testData = queries.flatMap((query) =>
+    Object.keys(query.queries).map((queryName) => ({
+        endpointName: query.endpointName,
+        endpointUrl: query.endpointUrl,
+        queryName: queryName,
+        queryString: query.queries[queryName],
+    })),
+);
+
+test.each(testData)(
+    // TODO: the variable interpolation from jest gets escaped by the VSCode jest extension,
+    //       meaning that the test will get skipped when you debug from VSCode.
+    //       If you need to debug, commend the test name and uncomment the one without variables.
+    // `run test query and check its duration`,
+    `run test query $queryName against $endpointName and check its duration`,
+    ({ endpointUrl, queryString }) => {
+        expect.assertions(1);
+
+        const runner = new QueryRunner(endpointUrl);
+        const elapsedTimeMs = runner.runTestQuery(queryString);
+
+        // TODO: support different expected run times per query
+        return expect(elapsedTimeMs).resolves.toBeLessThan(2000);
+    },
+);

--- a/src/queries/query_runner.ts
+++ b/src/queries/query_runner.ts
@@ -2,23 +2,25 @@ import { Quad, Stream } from 'rdf-js';
 import StreamClient from 'sparql-http-client';
 
 /**
- * A collection of test SPARQL queries.
+ * A class which can execute SPARQL queries against endpoints and measure their execution.
  */
-export class Queries {
+export class QueryRunner {
+    constructor(private endpointUrl: string) {}
+
     /**
-     * Run test query.
+     * Execute given SELECT query and return the elapsed time.
+     *
+     * @param {string} query The SELECT query to execute.
      *
      * @return {Promise<number>} Time elapsed in milliseconds.
      */
-    async runTestQuery(): Promise<number> {
+    async runTestQuery(query: string): Promise<number> {
         const client = new StreamClient({
-            endpointUrl: 'https://query.wikidata.org/sparql',
+            endpointUrl: this.endpointUrl,
         });
         const startTime = performance.now();
 
-        const stream = await client.query.construct(
-            'DESCRIBE <http://www.wikidata.org/entity/Q54872>',
-        );
+        const stream = await client.query.select(query);
         const endTime = await this.measureQueryEnd(stream);
 
         return endTime - startTime;

--- a/src/queries/sparql/eea.europa.eu/query1.sparql
+++ b/src/queries/sparql/eea.europa.eu/query1.sparql
@@ -1,0 +1,30 @@
+SELECT *
+WHERE { 
+    {
+        SELECT DISTINCT ?x ?pDomain (if(( ?pRangeLiteral = "" ), ?ppRange, ?pRangeLiteral) AS ?pRange)
+        WHERE {{
+            SELECT DISTINCT  ?x ?pDomain ?ppRange (if(isLiteral(?o), <http://hypergraphql.org/schema/Literal>, "") AS ?pRangeLiteral)
+            WHERE{ 
+                ?s  ?x  ?o
+                OPTIONAL { ?o  a ?ppRange }
+                OPTIONAL { ?s  a ?pDomain }
+            }
+        }}
+    }
+
+    ?x
+    (
+        (
+            ((<http://www.w3.org/2000/01/rdf-schema#subPropertyOf>|<http://www.w3.org/2002/07/owl#equivalentProperty>)|<http://www.w3.org/2002/07/owl#sameAs>)
+            |
+            <http://www.w3.org/2002/07/owl#equivalentClass>
+        )
+        |
+        ^(
+            (<http://www.w3.org/2002/07/owl#equivalentProperty>|<http://www.w3.org/2002/07/owl#sameAs>)|<http://www.w3.org/2002/07/owl#equivalentClass>
+        )
+    )*
+    ?predicate .
+}
+LIMIT 100
+OFFSET 0

--- a/src/queries/sparql/eea.europa.eu/query2.sparql
+++ b/src/queries/sparql/eea.europa.eu/query2.sparql
@@ -1,0 +1,6 @@
+SELECT DISTINCT ?s
+WHERE {
+    ?s rdf:type ?o
+}
+LIMIT 1000
+OFFSET 0

--- a/src/queries/sparql/eea.europa.eu/query3.sparql
+++ b/src/queries/sparql/eea.europa.eu/query3.sparql
@@ -1,0 +1,6 @@
+SELECT ?entity
+WHERE {
+    ?entity rdf:type/rdfs:subClassOf* ?object
+}
+LIMIT 1000
+OFFSET 0

--- a/src/queries/sparql/eea.europa.eu/query4.sparql
+++ b/src/queries/sparql/eea.europa.eu/query4.sparql
@@ -1,0 +1,9 @@
+SELECT DISTINCT ?pred
+WHERE {
+    ?x ?pred ?y .
+    {?pred rdf:equivalentProperty ?other}
+    UNION
+    {?other rdf:equivalentProperty ?pred}
+}
+LIMIT 100
+OFFSET 0

--- a/src/queries/sparql/query_collection.ts
+++ b/src/queries/sparql/query_collection.ts
@@ -1,0 +1,71 @@
+export type SparqlEndpointUrl = string;
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { sync } from 'glob';
+
+/**
+ * A collection of various queries tested during research.
+ *
+ * Queries are grouped by SPARQL endpoint.
+ */
+export class QueryCollection {
+    private endpointMapping: Record<string, SparqlEndpointUrl> = {
+        'data.gov.cz': 'https://data.gov.cz/sparql',
+        'eea.europa.eu': 'https://semantic.eea.europa.eu/sparql',
+    };
+
+    getQueries(endpointName?: string): EndpointQueryCollection[] {
+        const returnedQueries = [];
+        for (const currentEndpointName in this.endpointMapping) {
+            if (endpointName && endpointName !== currentEndpointName) {
+                continue;
+            }
+
+            returnedQueries.push(
+                this.getQueriesForEndpoint(currentEndpointName),
+            );
+        }
+
+        return returnedQueries;
+    }
+
+    private getQueriesForEndpoint(
+        endpointName: string,
+    ): EndpointQueryCollection {
+        const endpointPath = path.join(__dirname, endpointName);
+        if (!fs.existsSync(endpointPath)) {
+            return new EndpointQueryCollection(
+                endpointName,
+                this.endpointMapping[endpointName],
+                {},
+            );
+        }
+        const fileNames = sync(path.join(endpointPath, '*.sparql'));
+        const queries: Record<string, SparqlEndpointUrl> = {};
+        fileNames.forEach(
+            (fileName) =>
+                (queries[path.basename(fileName)] = fs
+                    .readFileSync(fileName)
+                    .toString()),
+        );
+
+        return new EndpointQueryCollection(
+            endpointName,
+            this.endpointMapping[endpointName],
+            queries,
+        );
+    }
+}
+
+/**
+ * Data class containing the list of queries for a particular SPARQL endpoint.
+ */
+export class EndpointQueryCollection {
+    constructor(
+        readonly endpointName: string,
+        readonly endpointUrl: SparqlEndpointUrl,
+        /** Map of query names to actual SPARQL query strings. */
+        readonly queries: Record<string, string>,
+    ) {}
+}

--- a/src/queries/sparql_query_demo.test.ts
+++ b/src/queries/sparql_query_demo.test.ts
@@ -1,9 +1,0 @@
-import { Queries } from './sparql_query_demo';
-
-test('run test query and check its duration', () => {
-    expect.assertions(1);
-
-    const elapsedTimeMs = new Queries().runTestQuery();
-
-    return expect(elapsedTimeMs).resolves.toBeLessThan(2000);
-});


### PR DESCRIPTION
This PR sets up query tests so that the queries can be stored in `.sparql` files in the source code, and the queries will be automatically collected and tested.

Currently the queries are organized per-endpoint, but maybe it would make sense in the future to create sets of queries which could then be run against configurable sets of endpoints.