### PR TITLE
feat(query-tests): group test queries into query collections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@types/sparql-http-client": "^2.2.7",
         "glob": "^7.2.0",
+        "nunjucks": "^3.2.3",
         "sparql-http-client": "^2.4.0"
       },
       "devDependencies": {
@@ -18,6 +18,8 @@
         "@babel/preset-typescript": "^7.16.0",
         "@types/glob": "^7.2.0",
         "@types/jest": "^27.0.2",
+        "@types/nunjucks": "^3.2.1",
+        "@types/sparql-http-client": "^2.2.7",
         "@typescript-eslint/eslint-plugin": "^5.3.0",
         "@typescript-eslint/parser": "^5.3.0",
         "babel-jest": "^27.3.1",
@@ -2393,6 +2395,12 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
       "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w=="
     },
+    "node_modules/@types/nunjucks": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.2.1.tgz",
+      "integrity": "sha512-hUh5HIC7peH+0MvlYU5KM2RydWxG1mBceivHsQGwlelU9zlczLICyJmjMwgjkI3m0+N50n46GVHkw35lIim6LQ==",
+      "dev": true
+    },
     "node_modules/@types/prettier": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.1.tgz",
@@ -2403,6 +2411,7 @@
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/@types/sparql-http-client/-/sparql-http-client-2.2.7.tgz",
       "integrity": "sha512-XTGiM3M8fKuvsLP4Ykx28Oltya2Ztfc7XZxmAOJkRG/yFqU0GM7AVXtjF/q/Xtkrio8c/TuNsmQWmoA3I2eIZg==",
+      "dev": true,
       "dependencies": {
         "rdf-js": "^4.0.2"
       }
@@ -2627,6 +2636,11 @@
         "node": "4.x || >=6.0.0"
       }
     },
+    "node_modules/a-sync-waterfall": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
+    },
     "node_modules/abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -2806,6 +2820,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -3189,6 +3208,14 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/concat-map": {
@@ -5638,6 +5665,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/nunjucks": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz",
+      "integrity": "sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==",
+      "dependencies": {
+        "a-sync-waterfall": "^1.0.0",
+        "asap": "^2.0.3",
+        "commander": "^5.1.0"
+      },
+      "bin": {
+        "nunjucks-precompile": "bin/precompile"
+      },
+      "engines": {
+        "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/nwsapi": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -5987,6 +6038,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
       "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
+      "dev": true,
       "dependencies": {
         "@rdfjs/types": "*"
       }
@@ -8813,6 +8865,12 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
       "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w=="
     },
+    "@types/nunjucks": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.2.1.tgz",
+      "integrity": "sha512-hUh5HIC7peH+0MvlYU5KM2RydWxG1mBceivHsQGwlelU9zlczLICyJmjMwgjkI3m0+N50n46GVHkw35lIim6LQ==",
+      "dev": true
+    },
     "@types/prettier": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.1.tgz",
@@ -8823,6 +8881,7 @@
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/@types/sparql-http-client/-/sparql-http-client-2.2.7.tgz",
       "integrity": "sha512-XTGiM3M8fKuvsLP4Ykx28Oltya2Ztfc7XZxmAOJkRG/yFqU0GM7AVXtjF/q/Xtkrio8c/TuNsmQWmoA3I2eIZg==",
+      "dev": true,
       "requires": {
         "rdf-js": "^4.0.2"
       }
@@ -8965,6 +9024,11 @@
         "whatwg-url": "^5.0.0"
       }
     },
+    "a-sync-waterfall": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
+    },
     "abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -9094,6 +9158,11 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -9398,6 +9467,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -11284,6 +11358,16 @@
         "path-key": "^3.0.0"
       }
     },
+    "nunjucks": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz",
+      "integrity": "sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==",
+      "requires": {
+        "a-sync-waterfall": "^1.0.0",
+        "asap": "^2.0.3",
+        "commander": "^5.1.0"
+      }
+    },
     "nwsapi": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -11534,6 +11618,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
       "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
+      "dev": true,
       "requires": {
         "@rdfjs/types": "*"
       }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "@babel/preset-typescript": "^7.16.0",
     "@types/glob": "^7.2.0",
     "@types/jest": "^27.0.2",
+    "@types/nunjucks": "^3.2.1",
+    "@types/sparql-http-client": "^2.2.7",
     "@typescript-eslint/eslint-plugin": "^5.3.0",
     "@typescript-eslint/parser": "^5.3.0",
     "babel-jest": "^27.3.1",
@@ -43,8 +45,8 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
-    "@types/sparql-http-client": "^2.2.7",
     "glob": "^7.2.0",
+    "nunjucks": "^3.2.3",
     "sparql-http-client": "^2.4.0"
   }
 }

--- a/src/queries/sparql/collection_config.ts
+++ b/src/queries/sparql/collection_config.ts
@@ -1,0 +1,42 @@
+import { QueryConfig } from './query_config';
+
+export class QueryCollectionConfig {
+    static readonly config: QueryCollectionDefinitionMap = {
+        small_queries: {
+            endpointNames: ['eea.europa.eu'],
+            config: {
+                templateConfig: {
+                    limit: 100,
+                    offset: 0,
+                },
+                executionConfig: {
+                    timeoutMs: 2000,
+                },
+            },
+        },
+        large_queries: {
+            endpointNames: ['eea.europa.eu'],
+            config: {
+                templateConfig: {
+                    limit: 1000,
+                    offset: 0,
+                },
+                executionConfig: {
+                    timeoutMs: 3000,
+                },
+            },
+        },
+    };
+}
+
+export type QueryCollectionDefinitionMap = Record<
+    string,
+    QueryCollectionDefinition
+>;
+
+export class QueryCollectionDefinition {
+    constructor(
+        readonly endpointNames: string[],
+        readonly config: QueryConfig,
+    ) {}
+}

--- a/src/queries/sparql/collection_config.ts
+++ b/src/queries/sparql/collection_config.ts
@@ -10,7 +10,7 @@ export class QueryCollectionConfig {
                     offset: 0,
                 },
                 executionConfig: {
-                    timeoutMs: 2000,
+                    timeoutMs: 5000,
                 },
             },
         },
@@ -22,7 +22,7 @@ export class QueryCollectionConfig {
                     offset: 0,
                 },
                 executionConfig: {
-                    timeoutMs: 3000,
+                    timeoutMs: 5000,
                 },
             },
         },

--- a/src/queries/sparql/collections/large_queries/query-002.sparql
+++ b/src/queries/sparql/collections/large_queries/query-002.sparql
@@ -2,5 +2,3 @@ SELECT DISTINCT ?s
 WHERE {
     ?s rdf:type ?o
 }
-LIMIT 1000
-OFFSET 0

--- a/src/queries/sparql/collections/large_queries/query-003.sparql
+++ b/src/queries/sparql/collections/large_queries/query-003.sparql
@@ -2,5 +2,3 @@ SELECT ?entity
 WHERE {
     ?entity rdf:type/rdfs:subClassOf* ?object
 }
-LIMIT 1000
-OFFSET 0

--- a/src/queries/sparql/collections/small_queries/query-001.sparql
+++ b/src/queries/sparql/collections/small_queries/query-001.sparql
@@ -1,3 +1,5 @@
+# TODO: document queries
+
 SELECT *
 WHERE { 
     {
@@ -26,5 +28,3 @@ WHERE {
     )*
     ?predicate .
 }
-LIMIT 100
-OFFSET 0

--- a/src/queries/sparql/collections/small_queries/query-004.sparql
+++ b/src/queries/sparql/collections/small_queries/query-004.sparql
@@ -5,5 +5,3 @@ WHERE {
     UNION
     {?other rdf:equivalentProperty ?pred}
 }
-LIMIT 100
-OFFSET 0

--- a/src/queries/sparql/endpoints.ts
+++ b/src/queries/sparql/endpoints.ts
@@ -1,0 +1,15 @@
+export type SparqlEndpointUrl = string;
+
+export class Endpoints {
+    static endpointMapping: Record<string, SparqlEndpointUrl> = {
+        'data.gov.cz': 'https://data.gov.cz/sparql',
+        'eea.europa.eu': 'https://semantic.eea.europa.eu/sparql',
+    };
+}
+
+export class EndpointDetails {
+    constructor(
+        readonly endpointName: string,
+        readonly endpointUrl: SparqlEndpointUrl,
+    ) {}
+}

--- a/src/queries/sparql/query_config.ts
+++ b/src/queries/sparql/query_config.ts
@@ -1,0 +1,14 @@
+export class QueryConfig {
+    constructor(
+        readonly templateConfig: QueryTemplateConfig,
+        readonly executionConfig?: QueryExecutionConfig,
+    ) {}
+}
+
+export class QueryTemplateConfig {
+    constructor(readonly limit: number, readonly offset: number) {}
+}
+
+export class QueryExecutionConfig {
+    constructor(readonly timeoutMs: number) {}
+}

--- a/src/queries/sparql/query_loader.ts
+++ b/src/queries/sparql/query_loader.ts
@@ -1,0 +1,27 @@
+import { QueryConfig } from './query_config';
+import * as fs from 'fs';
+import { renderString } from 'nunjucks';
+
+export class QueryLoader {
+    private readonly configTemplate: string =
+        'LIMIT {{ limit }}\nOFFSET {{ offset }}';
+
+    constructor(private readonly config: QueryConfig) {}
+
+    /**
+     * Load query with configured settings and return the query string.
+     * The configured options (limit, offset) will be appended
+     * to the end of the query.
+     *
+     * @param {string} filePath Path to the query file to load.
+     * @return {string} Loaded query string.
+     */
+    load_query(filePath: string): string {
+        const loadedQuery = fs.readFileSync(filePath).toString();
+        const renderedConfig = renderString(
+            this.configTemplate,
+            this.config.templateConfig,
+        );
+        return `${loadedQuery}\n${renderedConfig}`;
+    }
+}


### PR DESCRIPTION
This PR has 2 main features:

1. Queries are now grouped into named query collections. These collections are then executed against configured sets of SPARQL endpoints, meaning I can define a set of queries I want to test, and then test their performance across multiple endpoints easily.
2. Queries within a collection are now parametrized with `LIMIT` and `OFFSET` clauses. These are not defined in the query files themselves, but the configured values are read from `QueryCollectionConfig` and appended to all queries in the collection.