### PR TITLE
Add endpoint observations, object models and Apollo Server with generated GraphQL schema

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,10 +23,18 @@
     ],
     "rules": {
         "require-jsdoc": "off",
+        "valid-jsdoc": "off",
+        "new-cap": "off",
+        "no-multi-str": "off",
+        "@typescript-eslint/no-non-null-assertion": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/no-unused-vars": [
             "warn",
             {
-                "argsIgnorePattern": "^_"
+                "argsIgnorePattern": "^_",
+                "varsIgnorePattern": "^_",
+                "caughtErrorsIgnorePattern": "^_"
             }
         ]
     }

--- a/notes/active_endpoints.md
+++ b/notes/active_endpoints.md
@@ -1,0 +1,85 @@
+# List of active/maintained SPARQL endpoints
+
+## SPARQLES
+
+[SPARQL Endpoint Status](https://github.com/pyvandenbussche/sparqles) is a project
+developed to monitor the availability, performance, interoperability
+and discoverability of public SPARQL endpoints. There is an instance of it hosted
+by the Vienna University of Economics and Business [here](https://sparqles.ai.wu.ac.at/availability).
+
+This instance contains mutiple years' worth of data on SPARQL
+endpoints which are registered on [datahub.io](https://datahub.io).
+As of February 2022, 109 of 565 tracked endpoints were marked
+as available and operating normally. However, some of these
+endpoints are simply different-language versions of other
+endpoints, or versions of the same dataset across multiple
+institutions.
+
+Regardless, this list is useful for filtering out endpoints
+which do not even respond to requests.
+
+## List of verified endpoints we used
+
+The following is a curated list of endpoints which we used during
+our research. These endpoints are confirmed to be fully functional
+and available, and they contain meaningful data.
+
+### Narodni Katalog Otevrenych Dat - CZ Government
+
+https://data.gov.cz/sparql
+https://dev.nkod.opendata.cz/sparql
+
+### OpenData.cz
+
+https://linked.opendata.cz/sparql
+
+### DBPedia
+
+https://dbpedia.org/sparql
+
+### ScholarlyData.org
+
+Dataset of people, papers, organizations and conferences
+within the linked data sphere.
+
+http://www.scholarlydata.org/sparql/
+
+### WW1 as LOD
+
+https://ldf.fi/ww1lod/sparql
+
+### RUIAN - CZ Government
+
+Registry of land identification, addresses and properties
+in the Czech Republic
+
+https://ruian.linked.opendata.cz/sparql
+
+### Open data about the University of Oxford
+
+https://data.ox.ac.uk/sparql/
+
+### OpenEI - Open Energy Information
+
+https://openei.org/sparql
+
+### LinkedGeoData - OpenStreetMap in RDF
+
+http://linkedgeodata.org/sparql
+
+### Hungarian National Library catalog
+
+http://setaria.oszk.hu/sparql
+
+### European Environment Agency
+
+https://semantic.eea.europa.eu/sparql
+
+### UK Environment Agency bathing water quality
+
+https://environment.data.gov.uk/sparql/bwq/query
+https://environment.data.gov.uk/bwq/sparql.html
+
+### Allie database of abbreviations in life sciences
+
+http://data.allie.dbcls.jp/sparql

--- a/notes/inheritance.md
+++ b/notes/inheritance.md
@@ -1,0 +1,32 @@
+# Notes about inheritance
+
+We were interested whether it makes sense to query for
+inheritance in the form of something like this:
+
+`ns:Superclass a ns:Class a ns:Instance`
+
+We tested our list of endpoints with the following query:
+
+```sparql
+PREFIX se: <http://skodapetr.eu/ontology/sparql-endpoint/>
+CONSTRUCT {
+  [] se:class ?Class ;
+    se:superclass ?Superclass;
+    se:endpointUri "https://dev.nkod.opendata.cz/sparql";
+    se:numberOfInstances ?numberOfInstances .
+} WHERE {
+  {
+    SELECT ?Class ?Superclass (COUNT(?resource) AS ?numberOfInstances)
+    WHERE {
+      ?resource a ?Class.
+      ?Class a ?Superclass.
+    }
+    GROUP BY ?Class ?Superclass
+  }
+}
+```
+
+We found that this kind of inheritance was *exclusively* used
+for metadata annotations using RDFS, OWL or SHACL.
+Therefore it may not make sense to even query for this, when
+the available datasets do not make use of it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,12 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@graphql-tools/utils": "^8.6.5",
+        "apollo-server": "^3.6.7",
         "glob": "^7.2.0",
+        "graphql": "^16.3.0",
+        "lodash": "^4.17.21",
+        "nexus": "^1.3.0",
         "nunjucks": "^3.2.3",
         "sparql-http-client": "^2.4.0"
       },
@@ -18,6 +23,7 @@
         "@babel/preset-typescript": "^7.16.0",
         "@types/glob": "^7.2.0",
         "@types/jest": "^27.0.2",
+        "@types/lodash": "^4.14.181",
         "@types/nunjucks": "^3.2.1",
         "@types/sparql-http-client": "^2.2.7",
         "@typescript-eslint/eslint-plugin": "^5.3.0",
@@ -31,6 +37,56 @@
         "prettier": "^2.4.1",
         "ts-node": "^10.4.0",
         "typescript": "^4.4.4"
+      }
+    },
+    "node_modules/@apollo/protobufjs": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
+      "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "@types/node": "^10.1.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "apollo-pbjs": "bin/pbjs",
+        "apollo-pbts": "bin/pbts"
+      }
+    },
+    "node_modules/@apollo/protobufjs/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+    },
+    "node_modules/@apollographql/apollo-tools": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.5.3.tgz",
+      "integrity": "sha512-VcsXHfTFoCodDAgJZxN04GdFK1kqOhZQnQY/9Fa147P+I8xfvOSz5d+lKAPB+hwSgBNyd7ncAKGIs4+utbL+yA==",
+      "engines": {
+        "node": ">=8",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "graphql": "^14.2.1 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@apollographql/graphql-playground-html": {
+      "version": "1.6.29",
+      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.29.tgz",
+      "integrity": "sha512-xCcXpoz52rI4ksJSdOCxeOCn2DLocxwHf9dVT/Q90Pte1LX+LY+91SFtJF3KXVHH8kEin+g1KKCQPKBjZJfWNA==",
+      "dependencies": {
+        "xss": "^1.0.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1835,6 +1891,77 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@graphql-tools/merge": {
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.6.tgz",
+      "integrity": "sha512-dkwTm4czMISi/Io47IVvq2Fl9q4TIGKpJ0VZjuXYdEFkECyH6A5uwxZfPVandZG+gQs8ocFFoa6RisiUJLZrJw==",
+      "dependencies": {
+        "@graphql-tools/utils": "8.6.5",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/merge/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@graphql-tools/mock": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/mock/-/mock-8.6.4.tgz",
+      "integrity": "sha512-KhK8xrNb2knDjoWYz0hgCtmmoZ874pKcb1bTdyJ5sD8tBGtii05OdLUaueBKuvtX2lKZNcMSbloneQY6j8EbGA==",
+      "dependencies": {
+        "@graphql-tools/schema": "8.3.6",
+        "@graphql-tools/utils": "8.6.5",
+        "fast-json-stable-stringify": "^2.1.0",
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/mock/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@graphql-tools/schema": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.6.tgz",
+      "integrity": "sha512-7tWYRQ8hB/rv2zAtv2LtnQl4UybyJPtRz/VLKRmgi7+F5t8iYBahmmsxMDAYMWMmWMqEDiKk54TvAes+J069rQ==",
+      "dependencies": {
+        "@graphql-tools/merge": "8.2.6",
+        "@graphql-tools/utils": "8.6.5",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.11"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/schema/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@graphql-tools/utils": {
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
+      "dependencies": {
+        "tslib": "~2.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/utils/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
@@ -2151,6 +2278,11 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/@josephg/resolvable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@josephg/resolvable/-/resolvable-1.0.1.tgz",
+      "integrity": "sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg=="
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2185,6 +2317,60 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "node_modules/@rdfjs/data-model": {
       "version": "1.3.4",
@@ -2284,6 +2470,14 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/@types/accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.1.16",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.16.tgz",
@@ -2323,6 +2517,49 @@
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.3.0"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
+      "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw=="
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
       }
     },
     "node_modules/@types/glob": {
@@ -2384,6 +2621,22 @@
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
       "dev": true
     },
+    "node_modules/@types/lodash": {
+      "version": "4.14.181",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.181.tgz",
+      "integrity": "sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag==",
+      "dev": true
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -2406,6 +2659,25 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.1.tgz",
       "integrity": "sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw==",
       "dev": true
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/sparql-http-client": {
       "version": "2.2.7",
@@ -2647,6 +2919,18 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
@@ -2800,6 +3084,179 @@
         "node": ">= 8"
       }
     },
+    "node_modules/apollo-datasource": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-3.3.1.tgz",
+      "integrity": "sha512-Z3a8rEUXVPIZ1p8xrFL8bcNhWmhOmovgDArvwIwmJOBnh093ZpRfO+ESJEDAN4KswmyzCLDAwjsW4zQOONdRUw==",
+      "dependencies": {
+        "apollo-server-caching": "^3.3.0",
+        "apollo-server-env": "^4.2.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/apollo-reporting-protobuf": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.3.1.tgz",
+      "integrity": "sha512-tyvj3Vj71TCh6c8PtdHOLgHHBSJ05DF/A/Po3q8yfHTBkOPcOJZE/GGN/PT/pwKg7HHxKcAeHDw7+xciVvGx0w==",
+      "dependencies": {
+        "@apollo/protobufjs": "1.2.2"
+      }
+    },
+    "node_modules/apollo-server": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-3.6.7.tgz",
+      "integrity": "sha512-WERZqaVCkZJMoOc9y692NribgNtKbHDjOwiAmgXI2WBlON2oUvCwgxPvsMg+bXVpQx4itrMyj31a2N6BeKmbmQ==",
+      "dependencies": {
+        "apollo-server-core": "^3.6.7",
+        "apollo-server-express": "^3.6.7",
+        "express": "^4.17.1"
+      },
+      "peerDependencies": {
+        "graphql": "^15.3.0 || ^16.0.0"
+      }
+    },
+    "node_modules/apollo-server-caching": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-3.3.0.tgz",
+      "integrity": "sha512-Wgcb0ArjZ5DjQ7ID+tvxUcZ7Yxdbk5l1MxZL8D8gkyjooOkhPNzjRVQ7ubPoXqO54PrOMOTm1ejVhsF+AfIirQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/apollo-server-core": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.6.7.tgz",
+      "integrity": "sha512-OnZ9vu7LrYy2rvEu+nbgqucw6VyTSIPAEjK87c4rkzlVOxpwtGUaQ4FMWD9zBIj7yLq9q22b638E8LdYoaTAjQ==",
+      "dependencies": {
+        "@apollographql/apollo-tools": "^0.5.3",
+        "@apollographql/graphql-playground-html": "1.6.29",
+        "@graphql-tools/mock": "^8.1.2",
+        "@graphql-tools/schema": "^8.0.0",
+        "@josephg/resolvable": "^1.0.0",
+        "apollo-datasource": "^3.3.1",
+        "apollo-reporting-protobuf": "^3.3.1",
+        "apollo-server-caching": "^3.3.0",
+        "apollo-server-env": "^4.2.1",
+        "apollo-server-errors": "^3.3.1",
+        "apollo-server-plugin-base": "^3.5.2",
+        "apollo-server-types": "^3.5.2",
+        "async-retry": "^1.2.1",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graphql-tag": "^2.11.0",
+        "lodash.sortby": "^4.7.0",
+        "loglevel": "^1.6.8",
+        "lru-cache": "^6.0.0",
+        "sha.js": "^2.4.11",
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.3.0 || ^16.0.0"
+      }
+    },
+    "node_modules/apollo-server-env": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-4.2.1.tgz",
+      "integrity": "sha512-vm/7c7ld+zFMxibzqZ7SSa5tBENc4B0uye9LTfjJwGoQFY5xsUPH5FpO5j0bMUDZ8YYNbrF9SNtzc5Cngcr90g==",
+      "dependencies": {
+        "node-fetch": "^2.6.7"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/apollo-server-env/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/apollo-server-errors": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-3.3.1.tgz",
+      "integrity": "sha512-xnZJ5QWs6FixHICXHxUfm+ZWqqxrNuPlQ+kj5m6RtEgIpekOPssH/SD9gf2B4HuWV0QozorrygwZnux8POvyPA==",
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.3.0 || ^16.0.0"
+      }
+    },
+    "node_modules/apollo-server-express": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-3.6.7.tgz",
+      "integrity": "sha512-B4gH5j8t3XxTCIa9bl7Iq/F3YFzMxX/LV4Sc+L/3xkHm648u576G5Lkskl8HsoTGSzzyeVcVsPDoYHiBjCAN0Q==",
+      "dependencies": {
+        "@types/accepts": "^1.3.5",
+        "@types/body-parser": "1.19.2",
+        "@types/cors": "2.8.12",
+        "@types/express": "4.17.13",
+        "@types/express-serve-static-core": "4.17.28",
+        "accepts": "^1.3.5",
+        "apollo-server-core": "^3.6.7",
+        "apollo-server-types": "^3.5.2",
+        "body-parser": "^1.19.0",
+        "cors": "^2.8.5",
+        "parseurl": "^1.3.3"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "express": "^4.17.1",
+        "graphql": "^15.3.0 || ^16.0.0"
+      }
+    },
+    "node_modules/apollo-server-plugin-base": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.5.2.tgz",
+      "integrity": "sha512-SwIf1waDmNDb0kmn57QR++InwK6Iv/X2slpm/aFIoqFBe91r6uJfakJvQZuh8dLEgk68gxqFsT8zHRpxBclE+g==",
+      "dependencies": {
+        "apollo-server-types": "^3.5.2"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.3.0 || ^16.0.0"
+      }
+    },
+    "node_modules/apollo-server-types": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.5.2.tgz",
+      "integrity": "sha512-vhcbIWsBkoNibABOym4AAPBoNDjokhjUQokKYdwZMeqrb850PMQdNJFrGyXT5onP408Ghv4O8PfgBuPQmeJhVQ==",
+      "dependencies": {
+        "apollo-reporting-protobuf": "^3.3.1",
+        "apollo-server-caching": "^3.3.0",
+        "apollo-server-env": "^4.2.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.3.0 || ^16.0.0"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -2811,6 +3268,11 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -2825,6 +3287,14 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -3011,6 +3481,39 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-SAAwOxgoCKMGs9uUAUFHygfLAyaniaoun6I8mFY9pRAJL9+Kec34aU+oIjDhTycub1jozEfEwx1W1IuOYxVSFw==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.8.1",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.9.7",
+        "raw-body": "2.4.3",
+        "type-is": "~1.6.18"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3074,6 +3577,14 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -3264,6 +3775,25 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -3278,6 +3808,19 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "node_modules/core-js-compat": {
       "version": "3.19.1",
@@ -3307,6 +3850,18 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -3334,6 +3889,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
     },
     "node_modules/cssom": {
       "version": "0.4.4",
@@ -3473,6 +4033,19 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -3545,6 +4118,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.3.890",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.890.tgz",
@@ -3568,6 +4146,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -3597,6 +4183,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3901,6 +4492,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3974,6 +4573,59 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/express": {
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.3.tgz",
+      "integrity": "sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.2",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.2",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.9.7",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.17.2",
+        "serve-static": "1.14.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4017,8 +4669,7 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -4068,6 +4719,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -4112,6 +4793,22 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/fs.realpath": {
@@ -4281,6 +4978,33 @@
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
       "dev": true
     },
+    "node_modules/graphql": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.3.0.tgz",
+      "integrity": "sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || >=16.0.0"
+      }
+    },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/graphql-tag/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -4332,6 +5056,21 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -4372,7 +5111,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -4443,6 +5181,14 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/is-core-module": {
       "version": "2.8.0",
@@ -4612,6 +5358,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
     },
     "node_modules/jest": {
       "version": "27.3.1",
@@ -5453,11 +6204,32 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+    },
+    "node_modules/loglevel": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
+      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5504,6 +6276,19 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5519,6 +6304,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
@@ -5532,22 +6325,31 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mime-db": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
-      "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
-      "dev": true,
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.33",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
-      "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
-      "dev": true,
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dependencies": {
-        "mime-db": "1.50.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -5602,6 +6404,31 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/nexus": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/nexus/-/nexus-1.3.0.tgz",
+      "integrity": "sha512-w/s19OiNOs0LrtP7pBmD9/FqJHvZLmCipVRt6v1PM8cRUYIbhEswyNKGHVoC4eHZGPSnD+bOf5A3+gnbt0A5/A==",
+      "dependencies": {
+        "iterall": "^1.3.0",
+        "tslib": "^2.0.3"
+      },
+      "peerDependencies": {
+        "graphql": "15.x || 16.x"
+      }
+    },
+    "node_modules/nexus/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/node-fetch": {
       "version": "2.6.1",
@@ -5695,6 +6522,14 @@
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -5720,6 +6555,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
@@ -5816,6 +6662,14 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5847,6 +6701,11 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -5991,6 +6850,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -6015,6 +6886,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6033,6 +6915,28 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.3.tgz",
+      "integrity": "sha512-UlTNLIcu0uzb4D2f4WltY6cVjLi+/jEN4lgEUj3E04tpMDpUlkBo/eSn6zou9hum2VMNpCCUone0O0WeJim07g==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "1.8.1",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/rdf-js": {
       "version": "4.0.2",
@@ -6264,6 +7168,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -6334,8 +7246,7 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/saxes": {
       "version": "5.0.1",
@@ -6364,12 +7275,84 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
+      "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.8.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
     "node_modules/separate-stream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/separate-stream/-/separate-stream-1.0.1.tgz",
       "integrity": "sha512-UKFCzmddW2akOq40YdGehllv5gu6AD3y6nGSVuZuwI1kify2CiW7Zwsxx4ioaNLxx4LZaZMkcjdICHtSxpEpaA==",
       "dependencies": {
         "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
+      "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "bin": {
+        "sha.js": "bin.js"
       }
     },
     "node_modules/shebang-command": {
@@ -6476,6 +7459,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/string_decoder": {
@@ -6664,6 +7655,14 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
@@ -6792,6 +7791,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -6868,6 +7879,14 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -6881,6 +7900,22 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
@@ -6909,6 +7944,22 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/value-or-promise": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
+      "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/w3c-hr-time": {
@@ -7061,6 +8112,26 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
+    "node_modules/xss": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.11.tgz",
+      "integrity": "sha512-EimjrjThZeK2MO7WKR9mN5ZC1CSqivSl55wvUK5EtU6acf0rzEE1pN+9ZDrFXJ82BRp3JL38pPE6S4o/rpp1zQ==",
+      "dependencies": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "bin": {
+        "xss": "bin/xss"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/xss/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -7073,8 +8144,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -7114,6 +8184,47 @@
     }
   },
   "dependencies": {
+    "@apollo/protobufjs": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
+      "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "@types/node": "^10.1.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+        }
+      }
+    },
+    "@apollographql/apollo-tools": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.5.3.tgz",
+      "integrity": "sha512-VcsXHfTFoCodDAgJZxN04GdFK1kqOhZQnQY/9Fa147P+I8xfvOSz5d+lKAPB+hwSgBNyd7ncAKGIs4+utbL+yA==",
+      "requires": {}
+    },
+    "@apollographql/graphql-playground-html": {
+      "version": "1.6.29",
+      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.29.tgz",
+      "integrity": "sha512-xCcXpoz52rI4ksJSdOCxeOCn2DLocxwHf9dVT/Q90Pte1LX+LY+91SFtJF3KXVHH8kEin+g1KKCQPKBjZJfWNA==",
+      "requires": {
+        "xss": "^1.0.8"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
@@ -8388,6 +9499,73 @@
         "strip-json-comments": "^3.1.1"
       }
     },
+    "@graphql-tools/merge": {
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.6.tgz",
+      "integrity": "sha512-dkwTm4czMISi/Io47IVvq2Fl9q4TIGKpJ0VZjuXYdEFkECyH6A5uwxZfPVandZG+gQs8ocFFoa6RisiUJLZrJw==",
+      "requires": {
+        "@graphql-tools/utils": "8.6.5",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@graphql-tools/mock": {
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/mock/-/mock-8.6.4.tgz",
+      "integrity": "sha512-KhK8xrNb2knDjoWYz0hgCtmmoZ874pKcb1bTdyJ5sD8tBGtii05OdLUaueBKuvtX2lKZNcMSbloneQY6j8EbGA==",
+      "requires": {
+        "@graphql-tools/schema": "8.3.6",
+        "@graphql-tools/utils": "8.6.5",
+        "fast-json-stable-stringify": "^2.1.0",
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@graphql-tools/schema": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.6.tgz",
+      "integrity": "sha512-7tWYRQ8hB/rv2zAtv2LtnQl4UybyJPtRz/VLKRmgi7+F5t8iYBahmmsxMDAYMWMmWMqEDiKk54TvAes+J069rQ==",
+      "requires": {
+        "@graphql-tools/merge": "8.2.6",
+        "@graphql-tools/utils": "8.6.5",
+        "tslib": "~2.3.0",
+        "value-or-promise": "1.0.11"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@graphql-tools/utils": {
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.5.tgz",
+      "integrity": "sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==",
+      "requires": {
+        "tslib": "~2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
@@ -8642,6 +9820,11 @@
         "chalk": "^4.0.0"
       }
     },
+    "@josephg/resolvable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@josephg/resolvable/-/resolvable-1.0.1.tgz",
+      "integrity": "sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -8667,6 +9850,60 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@rdfjs/data-model": {
       "version": "1.3.4",
@@ -8754,6 +9991,14 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "@types/accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.16",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.16.tgz",
@@ -8793,6 +10038,49 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
+      }
+    },
+    "@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/cors": {
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
+      "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw=="
+    },
+    "@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
       }
     },
     "@types/glob": {
@@ -8854,6 +10142,22 @@
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.181",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.181.tgz",
+      "integrity": "sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag==",
+      "dev": true
+    },
+    "@types/long": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+    },
+    "@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+    },
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -8876,6 +10180,25 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.1.tgz",
       "integrity": "sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw==",
       "dev": true
+    },
+    "@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+    },
+    "@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+    },
+    "@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "requires": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "@types/sparql-http-client": {
       "version": "2.2.7",
@@ -9035,6 +10358,15 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
+    "accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "requires": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      }
+    },
     "acorn": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
@@ -9141,6 +10473,128 @@
         "picomatch": "^2.0.4"
       }
     },
+    "apollo-datasource": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-3.3.1.tgz",
+      "integrity": "sha512-Z3a8rEUXVPIZ1p8xrFL8bcNhWmhOmovgDArvwIwmJOBnh093ZpRfO+ESJEDAN4KswmyzCLDAwjsW4zQOONdRUw==",
+      "requires": {
+        "apollo-server-caching": "^3.3.0",
+        "apollo-server-env": "^4.2.1"
+      }
+    },
+    "apollo-reporting-protobuf": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.3.1.tgz",
+      "integrity": "sha512-tyvj3Vj71TCh6c8PtdHOLgHHBSJ05DF/A/Po3q8yfHTBkOPcOJZE/GGN/PT/pwKg7HHxKcAeHDw7+xciVvGx0w==",
+      "requires": {
+        "@apollo/protobufjs": "1.2.2"
+      }
+    },
+    "apollo-server": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-3.6.7.tgz",
+      "integrity": "sha512-WERZqaVCkZJMoOc9y692NribgNtKbHDjOwiAmgXI2WBlON2oUvCwgxPvsMg+bXVpQx4itrMyj31a2N6BeKmbmQ==",
+      "requires": {
+        "apollo-server-core": "^3.6.7",
+        "apollo-server-express": "^3.6.7",
+        "express": "^4.17.1"
+      }
+    },
+    "apollo-server-caching": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-3.3.0.tgz",
+      "integrity": "sha512-Wgcb0ArjZ5DjQ7ID+tvxUcZ7Yxdbk5l1MxZL8D8gkyjooOkhPNzjRVQ7ubPoXqO54PrOMOTm1ejVhsF+AfIirQ==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "apollo-server-core": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.6.7.tgz",
+      "integrity": "sha512-OnZ9vu7LrYy2rvEu+nbgqucw6VyTSIPAEjK87c4rkzlVOxpwtGUaQ4FMWD9zBIj7yLq9q22b638E8LdYoaTAjQ==",
+      "requires": {
+        "@apollographql/apollo-tools": "^0.5.3",
+        "@apollographql/graphql-playground-html": "1.6.29",
+        "@graphql-tools/mock": "^8.1.2",
+        "@graphql-tools/schema": "^8.0.0",
+        "@josephg/resolvable": "^1.0.0",
+        "apollo-datasource": "^3.3.1",
+        "apollo-reporting-protobuf": "^3.3.1",
+        "apollo-server-caching": "^3.3.0",
+        "apollo-server-env": "^4.2.1",
+        "apollo-server-errors": "^3.3.1",
+        "apollo-server-plugin-base": "^3.5.2",
+        "apollo-server-types": "^3.5.2",
+        "async-retry": "^1.2.1",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graphql-tag": "^2.11.0",
+        "lodash.sortby": "^4.7.0",
+        "loglevel": "^1.6.8",
+        "lru-cache": "^6.0.0",
+        "sha.js": "^2.4.11",
+        "uuid": "^8.0.0"
+      }
+    },
+    "apollo-server-env": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-4.2.1.tgz",
+      "integrity": "sha512-vm/7c7ld+zFMxibzqZ7SSa5tBENc4B0uye9LTfjJwGoQFY5xsUPH5FpO5j0bMUDZ8YYNbrF9SNtzc5Cngcr90g==",
+      "requires": {
+        "node-fetch": "^2.6.7"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        }
+      }
+    },
+    "apollo-server-errors": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-3.3.1.tgz",
+      "integrity": "sha512-xnZJ5QWs6FixHICXHxUfm+ZWqqxrNuPlQ+kj5m6RtEgIpekOPssH/SD9gf2B4HuWV0QozorrygwZnux8POvyPA==",
+      "requires": {}
+    },
+    "apollo-server-express": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-3.6.7.tgz",
+      "integrity": "sha512-B4gH5j8t3XxTCIa9bl7Iq/F3YFzMxX/LV4Sc+L/3xkHm648u576G5Lkskl8HsoTGSzzyeVcVsPDoYHiBjCAN0Q==",
+      "requires": {
+        "@types/accepts": "^1.3.5",
+        "@types/body-parser": "1.19.2",
+        "@types/cors": "2.8.12",
+        "@types/express": "4.17.13",
+        "@types/express-serve-static-core": "4.17.28",
+        "accepts": "^1.3.5",
+        "apollo-server-core": "^3.6.7",
+        "apollo-server-types": "^3.5.2",
+        "body-parser": "^1.19.0",
+        "cors": "^2.8.5",
+        "parseurl": "^1.3.3"
+      }
+    },
+    "apollo-server-plugin-base": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.5.2.tgz",
+      "integrity": "sha512-SwIf1waDmNDb0kmn57QR++InwK6Iv/X2slpm/aFIoqFBe91r6uJfakJvQZuh8dLEgk68gxqFsT8zHRpxBclE+g==",
+      "requires": {
+        "apollo-server-types": "^3.5.2"
+      }
+    },
+    "apollo-server-types": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.5.2.tgz",
+      "integrity": "sha512-vhcbIWsBkoNibABOym4AAPBoNDjokhjUQokKYdwZMeqrb850PMQdNJFrGyXT5onP408Ghv4O8PfgBuPQmeJhVQ==",
+      "requires": {
+        "apollo-reporting-protobuf": "^3.3.1",
+        "apollo-server-caching": "^3.3.0",
+        "apollo-server-env": "^4.2.1"
+      }
+    },
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -9153,6 +10607,11 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -9163,6 +10622,14 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "requires": {
+        "retry": "0.13.1"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -9314,6 +10781,38 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-SAAwOxgoCKMGs9uUAUFHygfLAyaniaoun6I8mFY9pRAJL9+Kec34aU+oIjDhTycub1jozEfEwx1W1IuOYxVSFw==",
+      "requires": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.8.1",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.9.7",
+        "raw-body": "2.4.3",
+        "type-is": "~1.6.18"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -9364,6 +10863,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
     },
     "call-bind": {
       "version": "1.0.2",
@@ -9518,6 +11022,19 @@
         }
       }
     },
+    "content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "requires": {
+        "safe-buffer": "5.2.1"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
     "convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -9534,6 +11051,16 @@
           "dev": true
         }
       }
+    },
+    "cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "core-js-compat": {
       "version": "3.19.1",
@@ -9557,6 +11084,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "create-require": {
       "version": "1.1.1",
@@ -9582,6 +11118,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
     },
     "cssom": {
       "version": "0.4.4",
@@ -9693,6 +11234,16 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -9746,6 +11297,11 @@
         }
       }
     },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
     "electron-to-chromium": {
       "version": "1.3.890",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.890.tgz",
@@ -9763,6 +11319,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -9786,6 +11347,11 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "4.0.0",
@@ -9996,6 +11562,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
     "execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -10049,6 +11620,58 @@
         }
       }
     },
+    "express": {
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.3.tgz",
+      "integrity": "sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==",
+      "requires": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.2",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.2",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.9.7",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.17.2",
+        "serve-static": "1.14.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10088,8 +11711,7 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -10133,6 +11755,35 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -10169,6 +11820,16 @@
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
+    },
+    "forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -10290,6 +11951,26 @@
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
       "dev": true
     },
+    "graphql": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.3.0.tgz",
+      "integrity": "sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A=="
+    },
+    "graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -10326,6 +12007,18 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      }
+    },
     "http-proxy-agent": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -10357,7 +12050,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -10407,6 +12099,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "is-core-module": {
       "version": "2.8.0",
@@ -10536,6 +12233,11 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
+    },
+    "iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
     },
     "jest": {
       "version": "27.3.1",
@@ -11189,11 +12891,25 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+    },
+    "loglevel": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
+      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA=="
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -11230,6 +12946,16 @@
         "tmpl": "1.0.5"
       }
     },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -11242,6 +12968,11 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
     "micromatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
@@ -11252,19 +12983,22 @@
         "picomatch": "^2.2.3"
       }
     },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
     "mime-db": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
-      "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
-      "dev": true
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
-      "version": "2.1.33",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
-      "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
-      "dev": true,
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "requires": {
-        "mime-db": "1.50.0"
+        "mime-db": "1.52.0"
       }
     },
     "mimic-fn": {
@@ -11307,6 +13041,27 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "nexus": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/nexus/-/nexus-1.3.0.tgz",
+      "integrity": "sha512-w/s19OiNOs0LrtP7pBmD9/FqJHvZLmCipVRt6v1PM8cRUYIbhEswyNKGHVoC4eHZGPSnD+bOf5A3+gnbt0A5/A==",
+      "requires": {
+        "iterall": "^1.3.0",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
     },
     "node-fetch": {
       "version": "2.6.1",
@@ -11374,6 +13129,11 @@
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -11390,6 +13150,14 @@
         "define-properties": "^1.1.3",
         "has-symbols": "^1.0.1",
         "object-keys": "^1.1.1"
+      }
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
       }
     },
     "once": {
@@ -11462,6 +13230,11 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
     },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -11484,6 +13257,11 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "path-type": {
       "version": "4.0.0",
@@ -11588,6 +13366,15 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "requires": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      }
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -11609,10 +13396,31 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw=="
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.3.tgz",
+      "integrity": "sha512-UlTNLIcu0uzb4D2f4WltY6cVjLi+/jEN4lgEUj3E04tpMDpUlkBo/eSn6zou9hum2VMNpCCUone0O0WeJim07g==",
+      "requires": {
+        "bytes": "3.1.2",
+        "http-errors": "1.8.1",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
     },
     "rdf-js": {
       "version": "4.0.2",
@@ -11811,6 +13619,11 @@
       "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
       "dev": true
     },
+    "retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
+    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -11843,8 +13656,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "saxes": {
       "version": "5.0.1",
@@ -11864,12 +13676,79 @@
         "lru-cache": "^6.0.0"
       }
     },
+    "send": {
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
+      "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.8.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
     "separate-stream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/separate-stream/-/separate-stream-1.0.1.tgz",
       "integrity": "sha512-UKFCzmddW2akOq40YdGehllv5gu6AD3y6nGSVuZuwI1kify2CiW7Zwsxx4ioaNLxx4LZaZMkcjdICHtSxpEpaA==",
       "requires": {
         "readable-stream": "^3.6.0"
+      }
+    },
+    "serve-static": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
+      "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.2"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shebang-command": {
@@ -11961,6 +13840,11 @@
           "dev": true
         }
       }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -12106,6 +13990,11 @@
         "is-number": "^7.0.0"
       }
     },
+    "toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+    },
     "tough-cookie": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
@@ -12191,6 +14080,15 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
     },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -12245,6 +14143,11 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -12258,6 +14161,16 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -12283,6 +14196,16 @@
           "dev": true
         }
       }
+    },
+    "value-or-promise": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
+      "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg=="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -12402,6 +14325,22 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
+    "xss": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.11.tgz",
+      "integrity": "sha512-EimjrjThZeK2MO7WKR9mN5ZC1CSqivSl55wvUK5EtU6acf0rzEE1pN+9ZDrFXJ82BRp3JL38pPE6S4o/rpp1zQ==",
+      "requires": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        }
+      }
+    },
     "y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -12411,8 +14350,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Connecting SPARQL and GraphQL!",
   "main": "src/experiments/sparql_query_demo.ts",
   "scripts": {
+    "start": "ts-node src/api/index.ts",
     "build": "tsc",
     "lint": "eslint \"src/**\"",
     "format": "eslint --fix \"src/**\"",
@@ -30,6 +31,7 @@
     "@babel/preset-typescript": "^7.16.0",
     "@types/glob": "^7.2.0",
     "@types/jest": "^27.0.2",
+    "@types/lodash": "^4.14.181",
     "@types/nunjucks": "^3.2.1",
     "@types/sparql-http-client": "^2.2.7",
     "@typescript-eslint/eslint-plugin": "^5.3.0",
@@ -45,7 +47,12 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
+    "@graphql-tools/utils": "^8.6.5",
+    "apollo-server": "^3.6.7",
     "glob": "^7.2.0",
+    "graphql": "^16.3.0",
+    "lodash": "^4.17.21",
+    "nexus": "^1.3.0",
     "nunjucks": "^3.2.3",
     "sparql-http-client": "^2.4.0"
   }

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -1,0 +1,9 @@
+import { ENDPOINTS } from '../observation/endpoints';
+
+// This file hosts various application configuration values separated from code
+
+export const ENDPOINT_TO_RUN = ENDPOINTS[6];
+export const EXAMINE_N_CLASSES = 10;
+
+export const PORT = 4000;
+export const DETAILED_LOG = false;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,24 @@
+import { ApolloServer } from 'apollo-server';
+import { EndpointObserver } from '../observation/observer';
+import { ObservationParser } from '../parsing/parser';
+import { ENDPOINT_TO_RUN, EXAMINE_N_CLASSES, PORT } from './config';
+import { createSchema } from './schema';
+
+// Carry out endpoint observations and start the GraphQL server
+const observer = new EndpointObserver();
+const parser = new ObservationParser();
+console.log('Observing endpoint, this may take a while...');
+observer.observeEndpoint(ENDPOINT_TO_RUN, EXAMINE_N_CLASSES).then((results) => {
+    console.log('Building object model...');
+    const classes = parser.buildEndpointModel(results);
+
+    console.log('Creating GraphQL schema...');
+    const schema = createSchema(classes);
+
+    console.log('Starting GraphQL server...');
+    const server = new ApolloServer({ schema });
+
+    server.listen({ port: PORT }).then(({ url }) => {
+        console.log(`🚀  Server ready at ${url}`);
+    });
+});

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -1,0 +1,82 @@
+import { makeSchema, queryType } from 'nexus';
+import {
+    NexusGraphQLSchema,
+    NexusObjectTypeDef,
+    objectType,
+} from 'nexus/dist/core';
+import { ClassDescriptor } from '../models/class';
+
+/**
+ * Generate a complete GraphQL schema from class descriptors.
+ * This schema may then be used by a GraphQL server.
+ *
+ * @param classes Class descriptors describing the SPARQL endpoint.
+ * @return Generated GraphQL schema.
+ */
+export function createSchema(classes: ClassDescriptor[]): NexusGraphQLSchema {
+    const endpointTypes = createEndpointTypes(classes);
+
+    // TODO: add resolvers functionality (big feature)
+    const query = queryType({
+        definition(t) {
+            for (const classDescriptor of classes) {
+                t.field(classDescriptor.name, {
+                    type: classDescriptor.name,
+                });
+            }
+        },
+    });
+
+    const schema = makeSchema({
+        types: [query, ...endpointTypes],
+    });
+
+    return schema;
+}
+
+function createEndpointTypes(
+    classes: ClassDescriptor[],
+): NexusObjectTypeDef<any>[] {
+    return classes.map((classDescriptor) =>
+        objectType({
+            name: classDescriptor.name,
+            definition(t) {
+                for (const attribute of classDescriptor.attributes) {
+                    const fieldConfig = {
+                        description: `This attribute has ${attribute.count} occurences.`,
+                    };
+                    if (attribute.type.endsWith('string')) {
+                        t.string(attribute.name, fieldConfig);
+                    } else if (attribute.type.endsWith('integer')) {
+                        t.int(attribute.name, fieldConfig);
+                    } else if (attribute.type.endsWith('boolean')) {
+                        t.boolean(attribute.name, fieldConfig);
+                    } else {
+                        // TODO: what should we do about other attribute types? Like dates or custom ones
+                        t.string(attribute.name, fieldConfig);
+                    }
+                }
+
+                for (const association of classDescriptor.associations) {
+                    t.field(association.name, {
+                        type: association.targetClass.name,
+                        description: `This association has ${association.count} occurences.`,
+                    });
+                }
+
+                if (
+                    classDescriptor.attributes.length === 0 &&
+                    classDescriptor.associations.length === 0
+                ) {
+                    t.boolean('DUMMY', {
+                        description:
+                            'This field is a placeholder, generated simply because this class has\
+                    no attributes or associations which were observed.',
+                    });
+                }
+            },
+            description: `Generated SPARQL class with ${classDescriptor.numberOfInstances} instances.\n
+Original IRI is ${classDescriptor.iri}.`,
+        }),
+    );
+}

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -66,8 +66,13 @@ Original IRI is ${association.iri}.`,
                     });
                 }
 
-                t.string('_rdf_iri', { description: 'IRI representing this particular object.' })
-                t.string('_rdf_type', { description: 'IRI representing the RDF type of this object.' })
+                t.string('_rdf_iri', {
+                    description: 'IRI representing this particular object.',
+                });
+                t.string('_rdf_type', {
+                    description:
+                        'IRI representing the RDF type of this object.',
+                });
             },
             description: `Generated SPARQL class with ${classDescriptor.numberOfInstances} instances.\n
 Original IRI is ${classDescriptor.iri}.`,

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -43,7 +43,8 @@ function createEndpointTypes(
             definition(t) {
                 for (const attribute of classDescriptor.attributes) {
                     const fieldConfig = {
-                        description: `This attribute has ${attribute.count} occurences.`,
+                        description: `This attribute has ${attribute.count} occurences.\n
+Original IRI is ${attribute.iri}.`,
                     };
                     if (attribute.type.endsWith('string')) {
                         t.string(attribute.name, fieldConfig);
@@ -60,20 +61,13 @@ function createEndpointTypes(
                 for (const association of classDescriptor.associations) {
                     t.field(association.name, {
                         type: association.targetClass.name,
-                        description: `This association has ${association.count} occurences.`,
+                        description: `This association has ${association.count} occurences.\n
+Original IRI is ${association.iri}.`,
                     });
                 }
 
-                if (
-                    classDescriptor.attributes.length === 0 &&
-                    classDescriptor.associations.length === 0
-                ) {
-                    t.boolean('DUMMY', {
-                        description:
-                            'This field is a placeholder, generated simply because this class has\
-                    no attributes or associations which were observed.',
-                    });
-                }
+                t.string('_rdf_iri', { description: 'IRI representing this particular object.' })
+                t.string('_rdf_type', { description: 'IRI representing the RDF type of this object.' })
             },
             description: `Generated SPARQL class with ${classDescriptor.numberOfInstances} instances.\n
 Original IRI is ${classDescriptor.iri}.`,

--- a/src/models/association.ts
+++ b/src/models/association.ts
@@ -1,0 +1,8 @@
+import { ClassDescriptor } from './class';
+
+export interface AssociationDescriptor {
+    iri: string;
+    name: string; // GraphQL friendly name - only contains [_a-zA-Z0-9]
+    targetClass: ClassDescriptor;
+    count: number;
+}

--- a/src/models/attribute.ts
+++ b/src/models/attribute.ts
@@ -1,0 +1,6 @@
+export interface AttributeDescriptor {
+    iri: string;
+    name: string; // GraphQL friendly name - only contains [_a-zA-Z0-9]
+    type: string;
+    count: number;
+}

--- a/src/models/class.ts
+++ b/src/models/class.ts
@@ -1,0 +1,12 @@
+import { AssociationDescriptor } from './association';
+import { AttributeDescriptor } from './attribute';
+import { InstanceDescriptor } from './instance';
+
+export interface ClassDescriptor {
+    iri: string;
+    name: string; // GraphQL friendly name - only contains [_a-zA-Z0-9]
+    numberOfInstances: number;
+    instances: InstanceDescriptor[];
+    attributes: AttributeDescriptor[];
+    associations: AssociationDescriptor[];
+}

--- a/src/models/instance.ts
+++ b/src/models/instance.ts
@@ -1,0 +1,3 @@
+export interface InstanceDescriptor {
+    iri: string;
+}

--- a/src/observation/client.ts
+++ b/src/observation/client.ts
@@ -1,10 +1,24 @@
 import { Quad } from 'rdf-js';
 import StreamClient from 'sparql-http-client';
+import { DETAILED_LOG } from '../api/config';
 import { SPARQLEndpointDefinition } from './endpoints';
 
+/**
+ * Class which executes SPARQL queries against the configured
+ * SPARQL endpoint, using the `method` function.
+ */
 export class EndpointClient {
-    constructor(private endpoint: SPARQLEndpointDefinition) { }
+    constructor(private endpoint: SPARQLEndpointDefinition) {}
 
+    /**
+     * Execute the given query against the configured SPARQL endpoint.
+     *
+     * Note that the function is asynchronous, because the request could
+     * take a long time to execute on some endpoints.
+     *
+     * @param query SPARQL query to execute
+     * @return `Promise` with results of the query
+     */
     async runQuery(query: string): Promise<QueryResult> {
         const client = new StreamClient({
             endpointUrl: this.endpoint.url,
@@ -12,7 +26,7 @@ export class EndpointClient {
         const startTime = performance.now();
         const stream = await client.query.construct(query);
 
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve, _reject) => {
             const quads: Quad[] = [];
             stream.on('data', (_quad: Quad) => {
                 quads.push(_quad);
@@ -34,11 +48,13 @@ export class EndpointClient {
         }).then((value) => {
             const queryResult = value as QueryResult;
 
-            console.debug(
-                `Got ${queryResult.quads.length} quads from ${this.endpoint.name} in ${(
-                    queryResult.elapsedTimeMs / 1000
-                ).toFixed(2)}s.`,
-            );
+            if (DETAILED_LOG) {
+                console.debug(
+                    `Got ${queryResult.quads.length} quads from ${
+                        this.endpoint.name
+                    } in ${(queryResult.elapsedTimeMs / 1000).toFixed(2)}s.`,
+                );
+            }
 
             return queryResult;
         });

--- a/src/observation/client.ts
+++ b/src/observation/client.ts
@@ -1,0 +1,56 @@
+import { Quad } from 'rdf-js';
+import StreamClient from 'sparql-http-client';
+import { SPARQLEndpointDefinition } from './endpoints';
+
+export class EndpointClient {
+    constructor(private endpoint: SPARQLEndpointDefinition) { }
+
+    async runQuery(query: string): Promise<QueryResult> {
+        const client = new StreamClient({
+            endpointUrl: this.endpoint.url,
+        });
+        const startTime = performance.now();
+        const stream = await client.query.construct(query);
+
+        return new Promise((resolve, reject) => {
+            const quads: Quad[] = [];
+            stream.on('data', (_quad: Quad) => {
+                quads.push(_quad);
+            });
+            stream.on('end', () => {
+                resolve({
+                    quads: quads,
+                    elapsedTimeMs: this.getElapsedTime(startTime),
+                    error: undefined,
+                });
+            });
+            stream.on('error', (error: any) => {
+                resolve({
+                    quads: quads,
+                    elapsedTimeMs: this.getElapsedTime(startTime),
+                    error: error,
+                });
+            });
+        }).then((value) => {
+            const queryResult = value as QueryResult;
+
+            console.debug(
+                `Got ${queryResult.quads.length} quads from ${this.endpoint.name} in ${(
+                    queryResult.elapsedTimeMs / 1000
+                ).toFixed(2)}s.`,
+            );
+
+            return queryResult;
+        });
+    }
+
+    private getElapsedTime(startTimeMs: number): number {
+        return performance.now() - startTimeMs;
+    }
+}
+
+export interface QueryResult {
+    quads: Quad[];
+    elapsedTimeMs: number;
+    error: any | undefined;
+}

--- a/src/observation/endpoints.ts
+++ b/src/observation/endpoints.ts
@@ -1,0 +1,59 @@
+export interface SPARQLEndpointDefinition {
+    url: string;
+    name: string;
+}
+
+export const ENDPOINTS: SPARQLEndpointDefinition[] = [
+    {
+        url: 'https://dev.nkod.opendata.cz/sparql',
+        name: 'NKOD',
+    },
+    {
+        url: 'https://linked.opendata.cz/sparql',
+        name: 'OpenData.cz',
+    },
+    {
+        url: 'http://dbpedia.org/sparql',
+        name: 'DBPedia',
+    },
+    {
+        url: 'http://www.scholarlydata.org/sparql/',
+        name: 'ScholarlyData.org',
+    },
+    {
+        url: 'https://ldf.fi/ww1lod/sparql',
+        name: 'WW1 as LOD',
+    },
+    {
+        url: 'https://ruian.linked.opendata.cz/sparql',
+        name: 'RUIAN',
+    },
+    {
+        url: 'https://data.ox.ac.uk/sparql/',
+        name: 'University of Oxford',
+    },
+    {
+        url: 'https://openei.org/sparql',
+        name: 'OpenEI',
+    },
+    {
+        url: 'http://linkedgeodata.org/sparql',
+        name: 'LinkedGeoData',
+    },
+    {
+        url: 'http://setaria.oszk.hu/sparql',
+        name: 'Hungarian National Library catalog',
+    },
+    {
+        url: 'https://semantic.eea.europa.eu/sparql',
+        name: 'European Environment Agency',
+    },
+    {
+        url: 'https://environment.data.gov.uk/sparql/bwq/query',
+        name: 'UK Environment Agency bathing water quality',
+    },
+    {
+        url: 'http://data.allie.dbcls.jp/sparql',
+        name: 'Allie database of abbreviations in life sciences',
+    },
+];

--- a/src/observation/endpoints.ts
+++ b/src/observation/endpoints.ts
@@ -3,6 +3,11 @@ export interface SPARQLEndpointDefinition {
     name: string;
 }
 
+/**
+ * List of pre-configured SPARQL endpoints for development.
+ *
+ * Can be extended at will.
+ */
 export const ENDPOINTS: SPARQLEndpointDefinition[] = [
     {
         url: 'https://dev.nkod.opendata.cz/sparql',

--- a/src/observation/observer.ts
+++ b/src/observation/observer.ts
@@ -1,0 +1,54 @@
+import { EndpointClient, QueryResult } from './client';
+import { ENDPOINTS } from './endpoints';
+import { QueryBuilder } from './query_builder';
+import { writeFileSync } from 'fs';
+
+export class EndpointObserver {
+    async observe(): Promise<QueryResult[][]> {
+        const allResults = [];
+        for (const endpoint of ENDPOINTS) {
+            const endpointResults = [];
+            const client = new EndpointClient(endpoint);
+
+            const query = QueryBuilder.CLASSES_AND_INSTANCE_NUMBERS();
+            const result = await client.runQuery(query);
+            endpointResults.push(result);
+
+            const classIriList = result.quads.filter(
+                x => x.predicate.value === 'http://skodapetr.eu/ontology/sparql-endpoint/class'
+            ).map(x => x.object.value);
+            for (const classIri of classIriList) {
+                const propQuery = QueryBuilder.NUMBER_OF_INSTANCE_PROPERTIES(classIri);
+                const propResult = await client.runQuery(propQuery);
+                endpointResults.push(propResult);
+
+                const instanceQuery = QueryBuilder.CLASS_INSTANCES(classIri);
+                const instanceResult = await client.runQuery(instanceQuery);
+                endpointResults.push(instanceResult);
+
+                const instanceIriList = instanceResult.quads.filter(
+                    x => x.predicate.value === 'http://skodapetr.eu/ontology/sparql-endpoint/resource'
+                ).map(x => x.object.value);
+                for (const instanceIri of instanceIriList) {
+                    const attributeQuery = QueryBuilder.INSTANCE_ATTRIBUTES(classIri, instanceIri);
+                    const attributeResult = await client.runQuery(attributeQuery);
+                    endpointResults.push(attributeResult);
+
+                    const associationQuery = QueryBuilder.INSTANCE_ASSOCIATIONS(classIri, instanceIri);
+                    const associationResult = await client.runQuery(associationQuery);
+                    endpointResults.push(associationResult);
+                }
+            }
+
+            allResults.push(endpointResults);
+            writeFileSync(`${endpoint.name}.json`, JSON.stringify(endpointResults));
+        }
+
+        return allResults;
+    }
+}
+
+const obs = new EndpointObserver();
+obs.observe().then((results) => {
+    console.log('Really done!');
+});

--- a/src/observation/observer.ts
+++ b/src/observation/observer.ts
@@ -1,54 +1,113 @@
 import { EndpointClient, QueryResult } from './client';
-import { ENDPOINTS } from './endpoints';
+import { ENDPOINTS, SPARQLEndpointDefinition } from './endpoints';
 import { QueryBuilder } from './query_builder';
 import { writeFileSync } from 'fs';
 
+/**
+ * Class which carries out observations of SPARQL endpoint contents.
+ *
+ * These observations can then be parsed into an object model,
+ * and subsequently converted to a GraphQL schema.
+ */
 export class EndpointObserver {
-    async observe(): Promise<QueryResult[][]> {
+    /**
+     * Carry out observations about all endpoints configured in `ENDPOINTS`
+     * in `./endpoints.ts`.
+     *
+     * This can take a **VERY** long time.
+     *
+     * @returns Observations about all endpoints
+     */
+    async observeAllEndpoints(): Promise<QueryResult[][]> {
         const allResults = [];
         for (const endpoint of ENDPOINTS) {
-            const endpointResults = [];
-            const client = new EndpointClient(endpoint);
-
-            const query = QueryBuilder.CLASSES_AND_INSTANCE_NUMBERS();
-            const result = await client.runQuery(query);
-            endpointResults.push(result);
-
-            const classIriList = result.quads.filter(
-                x => x.predicate.value === 'http://skodapetr.eu/ontology/sparql-endpoint/class'
-            ).map(x => x.object.value);
-            for (const classIri of classIriList) {
-                const propQuery = QueryBuilder.NUMBER_OF_INSTANCE_PROPERTIES(classIri);
-                const propResult = await client.runQuery(propQuery);
-                endpointResults.push(propResult);
-
-                const instanceQuery = QueryBuilder.CLASS_INSTANCES(classIri);
-                const instanceResult = await client.runQuery(instanceQuery);
-                endpointResults.push(instanceResult);
-
-                const instanceIriList = instanceResult.quads.filter(
-                    x => x.predicate.value === 'http://skodapetr.eu/ontology/sparql-endpoint/resource'
-                ).map(x => x.object.value);
-                for (const instanceIri of instanceIriList) {
-                    const attributeQuery = QueryBuilder.INSTANCE_ATTRIBUTES(classIri, instanceIri);
-                    const attributeResult = await client.runQuery(attributeQuery);
-                    endpointResults.push(attributeResult);
-
-                    const associationQuery = QueryBuilder.INSTANCE_ASSOCIATIONS(classIri, instanceIri);
-                    const associationResult = await client.runQuery(associationQuery);
-                    endpointResults.push(associationResult);
-                }
-            }
+            const endpointResults = await this.observeEndpoint(endpoint);
 
             allResults.push(endpointResults);
-            writeFileSync(`${endpoint.name}.json`, JSON.stringify(endpointResults));
+            writeFileSync(
+                `${endpoint.name}.json`,
+                JSON.stringify(endpointResults),
+            );
         }
 
         return allResults;
     }
-}
 
-const obs = new EndpointObserver();
-obs.observe().then((results) => {
-    console.log('Really done!');
-});
+    /**
+     * Carry out observations on the specified SPARQL endpoint.
+     *
+     * @param endpoint Endpoint to observe
+     * @param classSearchLimit If set to a value greater than zero,
+     *      only that many classes will be thoroughly searched, i.e.
+     *      their instances, properties and associations.
+     *      Limiting this number will speed up observation greatly.
+     * @returns Observations about the endpoint
+     */
+    async observeEndpoint(
+        endpoint: SPARQLEndpointDefinition,
+        classSearchLimit = 0,
+    ): Promise<QueryResult[]> {
+        const endpointResults = [];
+        const client = new EndpointClient(endpoint);
+
+        const query = QueryBuilder.CLASSES_AND_INSTANCE_NUMBERS();
+        const result = await client.runQuery(query);
+        endpointResults.push(result);
+
+        let classIriList = result.quads
+            .filter(
+                (x) =>
+                    x.predicate.value ===
+                    'http://skodapetr.eu/ontology/sparql-endpoint/class',
+            )
+            .map((x) => x.object.value);
+
+        if (classSearchLimit > 0) {
+            classIriList = classIriList.slice(0, classSearchLimit);
+        }
+
+        let classCount = 0;
+        for (const classIri of classIriList) {
+            console.debug(
+                `Observing class ${++classCount} of ${
+                    classIriList.length
+                } [${classIri}]`,
+            );
+            const propQuery =
+                QueryBuilder.NUMBER_OF_INSTANCE_PROPERTIES(classIri);
+            const propResult = await client.runQuery(propQuery);
+            endpointResults.push(propResult);
+
+            const instanceQuery = QueryBuilder.CLASS_INSTANCES(classIri);
+            const instanceResult = await client.runQuery(instanceQuery);
+            endpointResults.push(instanceResult);
+
+            const instanceIriList = instanceResult.quads
+                .filter(
+                    (x) =>
+                        x.predicate.value ===
+                        'http://skodapetr.eu/ontology/sparql-endpoint/resource',
+                )
+                .map((x) => x.object.value);
+            for (const instanceIri of instanceIriList) {
+                const attributeQuery = QueryBuilder.INSTANCE_ATTRIBUTES(
+                    classIri,
+                    instanceIri,
+                );
+                const attributeResult = await client.runQuery(attributeQuery);
+                endpointResults.push(attributeResult);
+
+                const associationQuery = QueryBuilder.INSTANCE_ASSOCIATIONS(
+                    classIri,
+                    instanceIri,
+                );
+                const associationResult = await client.runQuery(
+                    associationQuery,
+                );
+                endpointResults.push(associationResult);
+            }
+        }
+
+        return endpointResults;
+    }
+}

--- a/src/observation/query_builder.ts
+++ b/src/observation/query_builder.ts
@@ -1,3 +1,7 @@
+/**
+ * Use this builder's static functions to build SPARQL queries
+ * which can be used to carry out endpoint observations.
+ */
 export class QueryBuilder {
     static CLASSES_AND_INSTANCE_NUMBERS = () =>
         `PREFIX se: <http://skodapetr.eu/ontology/sparql-endpoint/>
@@ -29,7 +33,7 @@ export class QueryBuilder {
                 }
                 LIMIT 5
             }
-        }`
+        }`;
 
     static INSTANCE_ATTRIBUTES = (classIri: string, instanceIri: string) =>
         `PREFIX se: <http://skodapetr.eu/ontology/sparql-endpoint/>
@@ -48,7 +52,7 @@ export class QueryBuilder {
               FILTER isLiteral(?targetLiteral) 
             } LIMIT 5
           } 
-        }`
+        }`;
 
     static INSTANCE_ASSOCIATIONS = (classIri: string, instanceIri: string) =>
         `PREFIX se: <http://skodapetr.eu/ontology/sparql-endpoint/>
@@ -70,7 +74,7 @@ export class QueryBuilder {
             }
             GROUP BY ?class ?targetClass ?property
           } 
-        }`
+        }`;
 
     static NUMBER_OF_INSTANCE_PROPERTIES = (classIri: string) =>
         `PREFIX se: <http://skodapetr.eu/ontology/sparql-endpoint/>
@@ -94,5 +98,5 @@ export class QueryBuilder {
             }
             GROUP BY ?class ?targetClass ?property
           } 
-        }`
+        }`;
 }

--- a/src/observation/query_builder.ts
+++ b/src/observation/query_builder.ts
@@ -1,0 +1,98 @@
+export class QueryBuilder {
+    static CLASSES_AND_INSTANCE_NUMBERS = () =>
+        `PREFIX se: <http://skodapetr.eu/ontology/sparql-endpoint/>
+        CONSTRUCT {
+            [] se:class ?Class ;
+                se:numberOfInstances ?numberOfInstances .
+        } WHERE {
+            {
+                SELECT ?Class (COUNT(?resource) AS ?numberOfInstances)
+                WHERE {
+                    ?resource a ?Class.
+                }
+                GROUP BY ?Class
+            }
+        }`;
+
+    static CLASS_INSTANCES = (classIri: string) =>
+        `PREFIX se: <http://skodapetr.eu/ontology/sparql-endpoint/>
+        CONSTRUCT {
+            [] se:resource ?resource ;
+                se:class ?class .
+        } WHERE {
+            {
+                SELECT ?resource ?class WHERE {
+                    VALUES ( ?class ) {
+                        ( <${classIri}> )
+                    }
+                    ?resource a ?class .
+                }
+                LIMIT 5
+            }
+        }`
+
+    static INSTANCE_ATTRIBUTES = (classIri: string, instanceIri: string) =>
+        `PREFIX se: <http://skodapetr.eu/ontology/sparql-endpoint/>
+        CONSTRUCT {
+          [] se:property ?property ;
+            se:sourceClass ?class ;
+            se:targetLiteral ?targetLiteral .
+        } WHERE {
+          {
+            SELECT ?class ?targetLiteral  ?property
+            WHERE {
+              VALUES ( ?class ?resource ) {
+                ( <${classIri}> <${instanceIri}> )
+              }
+              ?resource ?property ?targetLiteral .
+              FILTER isLiteral(?targetLiteral) 
+            } LIMIT 5
+          } 
+        }`
+
+    static INSTANCE_ASSOCIATIONS = (classIri: string, instanceIri: string) =>
+        `PREFIX se: <http://skodapetr.eu/ontology/sparql-endpoint/>
+        CONSTRUCT {
+          [] se:property ?property ;
+            se:sourceClass ?class ;
+            se:targetClass ?targetClass .
+        } WHERE {
+          {
+            SELECT ?class ?targetClass ?property
+            WHERE {
+              VALUES ( ?class ?resource ) {
+                ( <${classIri}> <${instanceIri}> )
+              }
+              ?resource ?property ?targetResource .
+              OPTIONAL {
+                ?targetResource a ?targetClass .
+              }
+            }
+            GROUP BY ?class ?targetClass ?property
+          } 
+        }`
+
+    static NUMBER_OF_INSTANCE_PROPERTIES = (classIri: string) =>
+        `PREFIX se: <http://skodapetr.eu/ontology/sparql-endpoint/>
+        CONSTRUCT {
+          [] se:property ?property ;
+            se:sourceClass ?class ;
+            se:numberOfInstances ?numberOfInstances;
+            se:targetClass ?targetClass .
+        } WHERE {
+          {
+            SELECT ?class ?targetClass ?property (COUNT(*) AS ?numberOfInstances)
+            WHERE {
+              VALUES ( ?class ) {
+                ( <${classIri}>  )
+              }
+              ?s a ?class ;
+                ?property ?targetResource .
+              OPTIONAL {
+                ?targetResource a ?targetClass .
+              }
+            }
+            GROUP BY ?class ?targetClass ?property
+          } 
+        }`
+}

--- a/src/observation/query_builder.ts
+++ b/src/observation/query_builder.ts
@@ -18,6 +18,7 @@ export class QueryBuilder {
             }
         }`;
 
+    // TODO: make number of examined instances configurable
     static CLASS_INSTANCES = (classIri: string) =>
         `PREFIX se: <http://skodapetr.eu/ontology/sparql-endpoint/>
         CONSTRUCT {
@@ -31,7 +32,7 @@ export class QueryBuilder {
                     }
                     ?resource a ?class .
                 }
-                LIMIT 5
+                LIMIT 5 
             }
         }`;
 
@@ -50,7 +51,7 @@ export class QueryBuilder {
               }
               ?resource ?property ?targetLiteral .
               FILTER isLiteral(?targetLiteral) 
-            } LIMIT 5
+            }
           } 
         }`;
 

--- a/src/parsing/names.ts
+++ b/src/parsing/names.ts
@@ -1,4 +1,4 @@
-import { deburr } from "lodash";
+import { deburr } from 'lodash';
 
 /**
  * Update the names for the given descriptors using their IRIs.
@@ -20,11 +20,9 @@ export function buildNamesFromIRIs(
     // are present in the IRI. It will replace them with the accentless version,
     // rather than an underscore.
     for (const descriptor of descriptors) {
-        const shortName = deburr(descriptor.iri
-            .split(/[/#]/)
-            .slice(-1)
-            .pop()!)
-            .replace(/[^_a-zA-Z0-9]/gi, '_');
+        const shortName = deburr(
+            descriptor.iri.split(/[/#]/).slice(-1).pop()!,
+        ).replace(/[^_a-zA-Z0-9]/gi, '_');
         if (nameDict[shortName]) {
             nameDict[shortName].push(descriptor);
         } else {

--- a/src/parsing/names.ts
+++ b/src/parsing/names.ts
@@ -1,0 +1,44 @@
+/**
+ * Update the names for the given descriptors using their IRIs.
+ *
+ * The algorithm will attempt to give them a simplified short name for
+ * clarity in the schema, but if multiple entities would have the same
+ * short name, a long version will be used instead.
+ *
+ * @param descriptors Descriptors for which the names will be updated.
+ */
+export function buildNamesFromIRIs(
+    descriptors: { iri: string; name: string }[],
+) {
+    const nameDict: { [name: string]: { iri: string; name: string }[] } = {};
+
+    // Make a dictionary to detect conflicting short names
+    for (const descriptor of descriptors) {
+        const shortName = descriptor.iri
+            .split(/[/#]/)
+            .slice(-1)
+            .pop()!
+            .replace(/[^_a-zA-Z0-9]/gi, '_');
+        if (nameDict[shortName]) {
+            nameDict[shortName].push(descriptor);
+        } else {
+            nameDict[shortName] = [descriptor];
+        }
+    }
+
+    for (const [shortName, descriptors] of Object.entries(nameDict)) {
+        if (descriptors.length === 1) {
+            descriptors[0].name = shortName;
+        } else {
+            // In case of conflict of short name between classes, just give them all
+            // long unique names. This could probably be improved to take only
+            // as long of a name as necessary, not the whole IRI.
+            for (const descriptor of descriptors) {
+                descriptor.name = descriptor.iri.replace(
+                    /[^_a-zA-Z0-9]/gi,
+                    '_',
+                );
+            }
+        }
+    }
+}

--- a/src/parsing/names.ts
+++ b/src/parsing/names.ts
@@ -1,3 +1,5 @@
+import { deburr } from "lodash";
+
 /**
  * Update the names for the given descriptors using their IRIs.
  *
@@ -12,12 +14,16 @@ export function buildNamesFromIRIs(
 ) {
     const nameDict: { [name: string]: { iri: string; name: string }[] } = {};
 
-    // Make a dictionary to detect conflicting short names
+    // Make a dictionary to detect conflicting short names.
+    // Also make sure to deburr the name to make the resulting
+    // short names as readable as possible when things like accented characters
+    // are present in the IRI. It will replace them with the accentless version,
+    // rather than an underscore.
     for (const descriptor of descriptors) {
-        const shortName = descriptor.iri
+        const shortName = deburr(descriptor.iri
             .split(/[/#]/)
             .slice(-1)
-            .pop()!
+            .pop()!)
             .replace(/[^_a-zA-Z0-9]/gi, '_');
         if (nameDict[shortName]) {
             nameDict[shortName].push(descriptor);
@@ -34,7 +40,7 @@ export function buildNamesFromIRIs(
             // long unique names. This could probably be improved to take only
             // as long of a name as necessary, not the whole IRI.
             for (const descriptor of descriptors) {
-                descriptor.name = descriptor.iri.replace(
+                descriptor.name = deburr(descriptor.iri).replace(
                     /[^_a-zA-Z0-9]/gi,
                     '_',
                 );

--- a/src/parsing/parser.ts
+++ b/src/parsing/parser.ts
@@ -267,7 +267,9 @@ export class ObservationParser {
                                 (x) => x.iri === propertyQuad.object.value,
                             );
 
-                        // Interestingly, sometimes attributeDescriptor is not found. How is that possible?
+                        // When attributeDescriptor is not found, it means that the property was not on any
+                        // of the queried instances, i.e. the number of examined instances was too low.
+                        // TODO: what should happen in this case? Adding some kind of placeholder property?
                         if (attributeDescriptor) {
                             attributeDescriptor.count = parseInt(
                                 numInstancesQuad.object.value,

--- a/src/parsing/parser.ts
+++ b/src/parsing/parser.ts
@@ -1,0 +1,281 @@
+import { groupBy } from 'lodash';
+import { ClassDescriptor } from '../models/class';
+import { QueryResult } from '../observation/client';
+import { buildNamesFromIRIs } from './names';
+
+const OBS_PREFIX = 'http://skodapetr.eu/ontology/sparql-endpoint/';
+const OBS_CLASS = OBS_PREFIX + 'class';
+const OBS_NUM_INSTANCES = OBS_PREFIX + 'numberOfInstances';
+const OBS_RESOURCE = OBS_PREFIX + 'resource';
+const OBS_PROPERTY = OBS_PREFIX + 'property';
+const OBS_TARGET_LITERAL = OBS_PREFIX + 'targetLiteral';
+const OBS_SOURCE_CLASS = OBS_PREFIX + 'sourceClass';
+const OBS_TARGET_CLASS = OBS_PREFIX + 'targetClass';
+
+/**
+ * Class handling the parsing of SPARQL endpoint observations into an object model.
+ */
+export class ObservationParser {
+    /**
+     * Build our class model using the provided observations.
+     *
+     * @param observations Results of `EndpointObserver`'s observation of a SPARQL endpoint.
+     * @return Complete class model of the observed data.
+     */
+    buildEndpointModel(observations: QueryResult[]): ClassDescriptor[] {
+        // Creating class descriptors has to be done first
+        const classDescriptors = this.createClassDescriptors(observations);
+
+        this.createInstanceDescriptors(observations, classDescriptors);
+
+        // The order here is also important - create attribute and association
+        // descriptors before we update their counts.
+        this.createAttributeDescriptors(observations, classDescriptors);
+        this.createAssociationDescriptors(observations, classDescriptors);
+
+        this.createPropertyCountDescriptors(observations, classDescriptors);
+
+        // Convert IRIs into names and make them as short as possible
+        buildNamesFromIRIs(classDescriptors);
+        for (const classDescriptor of classDescriptors) {
+            // It's not a problem if these identifiers clash across classes.
+            // We do have to make sure that attributes and associations don't clash though.
+            buildNamesFromIRIs([
+                ...classDescriptor.attributes,
+                ...classDescriptor.associations,
+            ]);
+        }
+
+        return classDescriptors;
+    }
+
+    private createClassDescriptors(
+        observations: QueryResult[],
+    ): ClassDescriptor[] {
+        const descriptors: ClassDescriptor[] = [];
+
+        for (const queryResult of observations) {
+            const groupedResults = groupBy(
+                queryResult.quads,
+                (quad) => quad.subject.value,
+            );
+            for (const [_key, value] of Object.entries(groupedResults)) {
+                const classNameQuad = value.find(
+                    (x) => x.predicate.value === OBS_CLASS,
+                );
+
+                if (classNameQuad) {
+                    const numInstancesQuad = value.find(
+                        (x) => x.predicate.value === OBS_NUM_INSTANCES,
+                    );
+                    if (numInstancesQuad) {
+                        const newClass: ClassDescriptor = {
+                            iri: classNameQuad.object.value,
+                            name: '',
+                            numberOfInstances: parseInt(
+                                numInstancesQuad.object.value,
+                            ),
+                            instances: [],
+                            attributes: [],
+                            associations: [],
+                        };
+                        descriptors.push(newClass);
+                    }
+                }
+            }
+        }
+
+        return descriptors;
+    }
+
+    private createInstanceDescriptors(
+        observations: QueryResult[],
+        classes: ClassDescriptor[],
+    ) {
+        for (const queryResult of observations) {
+            const groupedResults = groupBy(
+                queryResult.quads,
+                (quad) => quad.subject.value,
+            );
+            for (const [_key, value] of Object.entries(groupedResults)) {
+                const resourceQuad = value.find(
+                    (x) => x.predicate.value === OBS_RESOURCE,
+                );
+                if (resourceQuad) {
+                    const classNameQuad = value.find(
+                        (x) => x.predicate.value === OBS_CLASS,
+                    );
+                    const classIri = classNameQuad!.object.value;
+                    const classDescriptor = classes.find(
+                        (x) => x.iri === classIri,
+                    )!;
+                    classDescriptor.instances.push({
+                        iri: resourceQuad.object.value,
+                    });
+                }
+            }
+        }
+    }
+
+    private createAttributeDescriptors(
+        observations: QueryResult[],
+        classes: ClassDescriptor[],
+    ) {
+        for (const queryResult of observations) {
+            const groupedResults = groupBy(
+                queryResult.quads,
+                (quad) => quad.subject.value,
+            );
+            for (const [_key, value] of Object.entries(groupedResults)) {
+                const literalQuad = value.find(
+                    (x) => x.predicate.value === OBS_TARGET_LITERAL,
+                );
+                if (literalQuad) {
+                    const propertyQuad = value.find(
+                        (x) => x.predicate.value === OBS_PROPERTY,
+                    )!;
+                    const classQuad = value.find(
+                        (x) => x.predicate.value === OBS_SOURCE_CLASS,
+                    )!;
+
+                    const classDescriptor = classes.find(
+                        (x) => x.iri === classQuad.object.value,
+                    )!;
+
+                    const attributeIri = propertyQuad.object.value;
+                    const attributeType: string =
+                        // @ts-ignore
+                        literalQuad.object.datatype.value;
+
+                    // Only add the attribute if it is not already there
+                    if (
+                        !classDescriptor.attributes.find(
+                            (x) =>
+                                x.iri === attributeIri &&
+                                x.type === attributeType,
+                        )
+                    ) {
+                        classDescriptor.attributes.push({
+                            iri: attributeIri,
+                            name: '',
+                            type: attributeType,
+                            count: 0,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    private createAssociationDescriptors(
+        observations: QueryResult[],
+        classes: ClassDescriptor[],
+    ) {
+        for (const queryResult of observations) {
+            const groupedResults = groupBy(
+                queryResult.quads,
+                (quad) => quad.subject.value,
+            );
+            for (const [_key, value] of Object.entries(groupedResults)) {
+                const targetClassQuad = value.find(
+                    (x) => x.predicate.value === OBS_TARGET_CLASS,
+                );
+                if (targetClassQuad) {
+                    const propertyQuad = value.find(
+                        (x) => x.predicate.value === OBS_PROPERTY,
+                    )!;
+                    const classQuad = value.find(
+                        (x) => x.predicate.value === OBS_SOURCE_CLASS,
+                    )!;
+
+                    const classDescriptor = classes.find(
+                        (x) => x.iri === classQuad.object.value,
+                    )!;
+
+                    const associationIri = propertyQuad.object.value;
+                    const targetClassIri = targetClassQuad.object.value;
+
+                    // Only add the attribute if it is not already there
+                    if (
+                        !classDescriptor.associations.find(
+                            (x) =>
+                                x.iri === associationIri &&
+                                x.targetClass.iri === targetClassIri,
+                        )
+                    ) {
+                        const targetClassDescriptor = classes.find(
+                            (x) => x.iri === targetClassIri,
+                        )!;
+                        classDescriptor.associations.push({
+                            iri: associationIri,
+                            name: '',
+                            targetClass: targetClassDescriptor,
+                            count: 0,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    private createPropertyCountDescriptors(
+        observations: QueryResult[],
+        classes: ClassDescriptor[],
+    ) {
+        for (const queryResult of observations) {
+            const groupedResults = groupBy(
+                queryResult.quads,
+                (quad) => quad.subject.value,
+            );
+            for (const [_key, value] of Object.entries(groupedResults)) {
+                const propertyQuad = value.find(
+                    (x) => x.predicate.value === OBS_PROPERTY,
+                );
+                const numInstancesQuad = value.find(
+                    (x) => x.predicate.value === OBS_NUM_INSTANCES,
+                );
+                const classQuad = value.find(
+                    (x) => x.predicate.value === OBS_SOURCE_CLASS,
+                );
+                if (propertyQuad && numInstancesQuad && classQuad) {
+                    const targetClassQuad = value.find(
+                        (x) => x.predicate.value === OBS_TARGET_CLASS,
+                    );
+
+                    const classDescriptor = classes.find(
+                        (x) => x.iri === classQuad.object.value,
+                    )!;
+
+                    // The descriptors already have to exist
+                    if (targetClassQuad) {
+                        const associationDescriptor =
+                            classDescriptor.associations.find(
+                                (x) =>
+                                    x.iri === propertyQuad.object.value &&
+                                    x.targetClass.iri ===
+                                        targetClassQuad.object.value,
+                            );
+                        associationDescriptor!.count = parseInt(
+                            numInstancesQuad.object.value,
+                        );
+                    } else {
+                        // TODO: is this filtering enough? Can we have duplicate attributes, in which case
+                        //       this would be inaccurate, because it would get assigned to the first one?
+                        //       Also the duplicates could be causing unnecessary name clashes.
+                        const attributeDescriptor =
+                            classDescriptor.attributes.find(
+                                (x) => x.iri === propertyQuad.object.value,
+                            );
+
+                        // Interestingly, sometimes attributeDescriptor is not found. How is that possible?
+                        if (attributeDescriptor) {
+                            attributeDescriptor.count = parseInt(
+                                numInstancesQuad.object.value,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/scripts/build_model.ts
+++ b/src/scripts/build_model.ts
@@ -1,0 +1,16 @@
+import { ENDPOINTS } from '../observation/endpoints';
+import { EndpointObserver } from '../observation/observer';
+import { ObservationParser } from '../parsing/parser';
+
+// Debug script for testing observations and parsing
+
+const obs = new EndpointObserver();
+const parser = new ObservationParser();
+obs.observeEndpoint(ENDPOINTS[6], 10).then((results) => {
+    const model = parser.buildEndpointModel(results);
+
+    console.log(`Done! Model has ${model.length} class descriptors.`);
+});
+// obs.observeAllEndpoints().then((results) => {
+//     console.log('Really done!');
+// });


### PR DESCRIPTION
This PR does the following things:

- adds endpoint observations, where specific queries are executed against a SPARQL endpoint, producing a list of quads (observations)
- adds the object models which represent the observed data model, as well as parsing logic for them
- adds Apollo Server, a GraphQL server
- adds creation of GraphQL schema using GraphQL Nexus. Nexus is a code-first approach to schema creation which IMO is much better for our use case than a schema-first approach, because we can more easily generate it automatically.

The result of this is a runnable instance of a GraphQL server which contains a schema which was automatically extracted from a given GraphQL endpoint. Note that the GraphQL endpoint is not queryable, since the resolvers still have not been implemented. Only the schema is implemented.

You can run it yourself by running `npm start` after installing all the dependencies with `npm install`. It will start a server on the configured port (default `localhost:4000`). When you visit this URL, it will redirect you to a playground which you can use to explore the schema. It will look something like this:

![image](https://user-images.githubusercontent.com/18127325/161136436-8c8c357a-57ca-458b-abde-bfd20bf0bc8d.png)

**NOTE**: if you inspect the config in `src/api/config.ts`, you will see which endpoint is configured as the default (Oxford University dataset), and that the search breadth is limited. This is to speed up the server start, and it means that only 10 classes will have attribute and association information. The rest will just have a placeholder field defined.